### PR TITLE
Refactor and update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+# IDEs
+.idea

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,8 +1,9 @@
 #! /usr/bin/env node
 
-const fs = require('fs')
+const fs = require('fs');
 const fetchSchema = require('../fetchSchema');
-var program = require('commander');
+const AirtableGraphQL = require('../index');
+const program = require('commander');
 
 program
   .command('pull')
@@ -17,6 +18,15 @@ program
     }).then(schema => {
       fs.writeFileSync('./schema.json', JSON.stringify(schema, null, 2), 'utf-8'); 
     })
-  })
+  });
+
+program
+  .command('start')
+  .option('-s --schema [path]', 'Path of the file containing Airtable schema', './schema.json')
+  .option('-p --port [port]', 'Port for the adapter to listen on', '8765')
+  .action(function (cmd) {
+    const api = new AirtableGraphQL(process.env.AIRTABLE_API_KEY, {schemaPath: cmd.schema});
+    api.listen({port: cmd.port}).then(() => console.log('done')).catch((e) => console.log(e));
+  });
 
 program.parse(process.argv);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -26,7 +26,7 @@ program
   .option('-p --port [port]', 'Port for the adapter to listen on', '8765')
   .action(function (cmd) {
     const api = new AirtableGraphQL(process.env.AIRTABLE_API_KEY, {schemaPath: cmd.schema});
-    api.listen({port: cmd.port}).then(() => console.log('done')).catch((e) => console.log(e));
+    api.listen({port: cmd.port});
   });
 
 program.parse(process.argv);

--- a/columns/number.js
+++ b/columns/number.js
@@ -8,15 +8,15 @@ module.exports = airtableGraphql => {
       }
 
       if (column.options.format === "currency") {
-        return { type: graphql.GraphQLString };
+        return { type: graphql.GraphQLFloat };
       }
 
       if (column.options.format === "percent") {
-        return { type: graphql.GraphQLString };
+        return { type: graphql.GraphQLInt };
       }
 
       if (column.options.format === "duration") {
-        return { type: graphql.GraphQLString };
+        return { type: graphql.GraphQLInt };
       }
 
       return { type: graphql.GraphQLInt };
@@ -24,14 +24,6 @@ module.exports = airtableGraphql => {
 
     resolver: (column, api) => (obj) => {
       let value = obj.fields[column.name];
-
-      if (column.options.format === "currency") {
-        value = `${column.options.symbol}${value}`;
-      }
-
-      if (column.options.format === "percent") {
-        value = `${value}%`;
-      }
 
       return value;
     }

--- a/convertSchema.js
+++ b/convertSchema.js
@@ -56,7 +56,8 @@ function reformatSchema(airtableSchema) {
 
         if (column.type === 'number') {
           options = {
-            format: column.typeOptions.format
+            format: column.typeOptions.format,
+            symbol: column.typeOptions.symbol
           }
         }
 

--- a/convertSchema.js
+++ b/convertSchema.js
@@ -11,15 +11,14 @@ const {
 } = require("graphql");
 const sanitize = require("./sanitize");
 
-module.exports = (airtableSchema, columnSupport) => {
-
+function reformatSchema(airtableSchema) {
   let tablesById = {};
 
   airtableSchema.tables.map(table => {
     tablesById[table.id] = table;
   });
-  
-  const modifiedSchema = {
+
+  return {
     tables: airtableSchema.tables.map(table => ({
       name: table.name,
       columns: table.columns.map(column => {
@@ -75,6 +74,9 @@ module.exports = (airtableSchema, columnSupport) => {
       })
     }))
   };
+}
+
+function convertSchema(airtableSchema, columnSupport) {
 
   const TYPES = [];
 
@@ -90,7 +92,7 @@ module.exports = (airtableSchema, columnSupport) => {
     type: new GraphQLList(GraphQLString)
   };
 
-  modifiedSchema.tables.forEach(table => {
+  airtableSchema.tables.forEach(table => {
     TYPES[table.name] = new GraphQLObjectType({
       name: sanitize.toType(table.name),
       fields: () => ({
@@ -125,4 +127,9 @@ module.exports = (airtableSchema, columnSupport) => {
   return new GraphQLSchema({
     query: new GraphQLObjectType(queryType)
   });
+}
+
+module.exports = {
+  reformatSchema,
+  convertSchema
 };

--- a/convertSchema.js
+++ b/convertSchema.js
@@ -21,7 +21,7 @@ function reformatSchema(airtableSchema) {
   return {
     tables: airtableSchema.tables.map(table => ({
       name: table.name,
-      columns: table.columns.map(column => {
+      columns: table.columns.filter(column => !['lookup', 'formula', 'rollup'].includes(column.type)).map(column => {
         let options = {};
 
         if (column.type === "select") {
@@ -51,12 +51,6 @@ function reformatSchema(airtableSchema) {
             choices: Object.values(column.typeOptions.choices).map(c => {
               return c.name
             })
-          }
-        }
-
-        if (column.type === 'number') {
-          options = {
-            format: column.typeOptions.format
           }
         }
 

--- a/fetchSchema.js
+++ b/fetchSchema.js
@@ -5,13 +5,11 @@ function removeForeignTables(obj) {
   if (typeof obj === 'object') {
     let result = {};
     for (let key in obj) {
-      console.log(`Visiting ${key}`);
       if (obj.hasOwnProperty(key) && key !== 'foreignTable') {
         result[key] = removeForeignTables(obj[key]);
       }
     }
     if (Array.isArray(obj)) {
-      console.log("Converting int-keyed dictionary to array");
       {
         let arrayResult = [];
         for (let i = 0; i < obj.length; i++) {
@@ -22,7 +20,6 @@ function removeForeignTables(obj) {
     }
     return result;
   } else {
-    console.log(`Returning scalar ${obj}`);
     return obj;
   }
 }

--- a/fetchSchema.js
+++ b/fetchSchema.js
@@ -10,55 +10,7 @@ module.exports = async config => {
   await page.keyboard.press("Enter");
   await page.waitForNavigation();
   const schema = await page.evaluate(() => {
-    return {
-      tables: application.tables.map(table => ({
-        name: table.name,
-        columns: table.columns.map(column => {
-          let options = {};
-
-          if (column.type === "select") {
-            options = {
-              choices: Object.values(column.typeOptions.choices).map(c => {
-                return c.name;
-              })
-            };
-          }
-
-          if (column.type === 'foreignKey') {
-            options = {
-              relationship: column.typeOptions.relationship,
-              table: column.foreignTable.name
-            }
-          }
-
-          if (column.type === 'multiSelect') {
-            options = {
-              choices: Object.values(column.typeOptions.choices).map(c => {
-                return c.name
-              })
-            }
-          }
-
-          if (column.type === 'number') {
-            options = {
-              format: column.typeOptions.format
-            }
-          }
-
-          if (column.type === 'number') {
-            options = {
-              format: column.typeOptions.format
-            }
-          }
-
-          return {
-            name: column.name,
-            type: column.type,
-            options: options
-          }
-        })
-      }))
-    };
+    return application;
   });
   await browser.close();
   return {

--- a/readme.md
+++ b/readme.md
@@ -22,10 +22,10 @@ $ airtable-graphql pull --email=[your_email] --password=[your_password] --base=[
 
 This will create a `schema.json` file which describes all of your bases tables and columns.
 
-Use the airtable-graphql command to start the adapter
+Use the `airtable-graphql start` command to start the adapter
 
 ```
-$ airtable-graphql start -s schema.json -p 8765
+$ AIRTABLE_API_KEY={{api_key}} airtable-graphql start -s schema.json -p 8765
 ```
 
 Open your browser to localhost:8765 to start writing GraphQL queries against your Airtable data.

--- a/readme.md
+++ b/readme.md
@@ -22,14 +22,12 @@ $ airtable-graphql pull --email=[your_email] --password=[your_password] --base=[
 
 This will create a `schema.json` file which describes all of your bases tables and columns.
 
-Create a file called `index.js` and add the following.
+Use the airtable-graphql command to start the adapter
 
-```js
-const AirtableGraphQL = require("airtable-graphql");
-api = new AirtableGraphQL("airtable_api_key");
-api.listen();
+```
+$ airtable-graphql start -s schema.json -p 8765
 ```
 
-Run `node index.js`
+Open your browser to localhost:8765 to start writing GraphQL queries against your Airtable data.
 
 That's it!


### PR DESCRIPTION
A few small changes:
- I moved a minor schema conversion task from fetchSchema to convertSchema. This makes it so users don't have to use the exact scraper written here to download the Airtable Schema
- My Airtable schema does not record foreign tables by `column.foreignTable.name`. Instead it is necessary to lookup the table name using the table identifier available at `column.typeOptions.foreignTableid`. If `column.foreignTable.name` exists in the schema we will still use this value.
- Added `airtable-graphql start` command to even further simplify starting the adapter